### PR TITLE
vocab cards on dom, with some weirdness

### DIFF
--- a/api/vocabData.js
+++ b/api/vocabData.js
@@ -1,0 +1,24 @@
+import client from '../utils/client';
+
+const endpoint = client.databaseURL; // this is the same as dburl in postman. here it can be traced back to APP_DATABASE_URL in .env.
+
+// GET VOCAB BY UID
+const getVocab = (uid) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/vocab.json?orderBy="uid"&equalTo="${uid}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data) {
+        resolve(Object.values(data)); // converts the data object returned by the fetch call into an array
+      } else {
+        resolve([]); // handle a null value from the API when there are no Vocab in the database
+      }
+    })
+    .catch(reject);
+});
+
+export default getVocab;

--- a/pages/vocab.js
+++ b/pages/vocab.js
@@ -1,1 +1,34 @@
-// this file will contain the card and the loop to show them all
+import clearDom from '../utils/clearDom';
+import renderToDOM from '../utils/renderToDom';
+
+const emptyVocab = () => {
+  const domString = '<h1>No Vocab</h1>';
+  renderToDOM('#store', domString);
+};
+
+const showVocab = (array) => {
+  clearDom();
+
+  if (array.length === 0) {
+    emptyVocab(); // if the array is empty, display "No Vocab"
+  } else {
+    // if the array is not empty, loop through the vocab items
+    let domString = '';
+    array.forEach((vocab) => {
+      domString += `<div class="card" style="width: 18rem;">
+  <div class="card-body">
+    <h5 class="card-title">${vocab.title}</h5>
+    <h6 class="card-subtitle mb-2 text-body-secondary">need to do merged promsie, rn is the firebase key: ${vocab.language}</h6>
+    <p class="card-text">${vocab.definition}</p>
+    <a href="#" class="card-link">Edit (placeholder)</a>
+    <a href="#" class="card-link">Delete (placeholder)</a>
+  </div>
+</div>`;
+    });
+    renderToDOM('#store', domString);
+  }
+};
+
+// todo: 1. the buttons. ohhh boy. and 2. display the language. see merged promises in amazon. authorobject.
+
+export { emptyVocab, showVocab };

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -3,8 +3,8 @@
 
 
 body {
-  background-color: antiquewhite;
-  color: brown;
+  background-color: #ffabf3;
+  color: rgb(0, 141, 28);
   text-align: center;
   margin-top: 100px;
 }

--- a/utils/clearDom.js
+++ b/utils/clearDom.js
@@ -1,0 +1,8 @@
+const clearDom = () => {
+  document.querySelector('#languages-container').innerHTML = '';
+  document.querySelector('#form-container').innerHTML = '';
+  document.querySelector('#store').innerHTML = '';
+  document.querySelector('#view').innerHTML = '';
+};
+
+export default clearDom;

--- a/utils/client.js
+++ b/utils/client.js
@@ -9,3 +9,6 @@ const client = {
 };
 
 export default client;
+
+// this has to do with firebase data. see similarities in .env file.
+// "This file is likely included in other parts of the application to configure services like Firebase or connect to an API using these environment-specific details."

--- a/utils/startApp.js
+++ b/utils/startApp.js
@@ -1,9 +1,12 @@
 import domBuilder from '../components/shared/domBuilder';
 import navBar from '../components/shared/navbar';
+import getVocab from '../api/vocabData';
+import { showVocab } from '../pages/vocab';
 
 const startApp = (user) => {
   domBuilder(user);
   navBar();
+  getVocab(user.uid).then((vocab) => showVocab(vocab));
 };
 
 export default startApp;


### PR DESCRIPTION
## Description
- api call to getVocab by uid
-clearDom fx
-showVocab fx: loops thru user's vocab, and if none exist, runs emptyVocab (displays "No Vocab")
- updated rules in firebase to index on vocab uid, so that my api call could actually work
Notes! 
- The vocab cards are weird. edit and delete button functionality still to do, so just placeholder for now. 
- the language on the vocab card is displaying the firebase key. need to do all above for languages (get, show, update startApp, etc.) and then do a merged promise so that i can actually display the language on the card, not display the firebase key of it's language.
## Related Issue
#25, #26, #28

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)